### PR TITLE
imp: atualiza documentação

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
         id: flake8_linter
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pr_number: ${{ github.event.number }}
+          pr_number: ${{ github.event.inputs.pr_number }}
 ```
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -42,8 +42,20 @@ Check the latest release [here](https://github.com/betrybe/flake8-linter-action/
 
 ```yml
 on:
-  pull_request:
-    types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      dispatch_token:
+        description: 'Token that authorize the dispatch'
+        required: true
+      head_sha:
+        description: 'Head commit SHA that dispatched the workflow'
+        required: true
+      pr_author_username:
+        description: 'Pull Request author username'
+        required: true
+      pr_number:
+        description: 'Pull Request number that dispatched the workflow'
+        required: true
 
 jobs:
   evaluator_job:
@@ -61,17 +73,17 @@ jobs:
 
 ## Inputs
 
-### `token`
+- `token`
 
-**Required**
+  **Required**
 
-The GitHub token to use for making API requests.
+  The GitHub token to use for making API requests.
 
-### `pr_number`
+- `pr_number`
 
-**Required**
+  **Required**
 
-Pull Request number that triggered the build.
+  Pull Request number that triggered the build.
 
 ## Configure rules and analysis via `setup.cfg`
 


### PR DESCRIPTION
Devido as alterações na [LEARN-869](https://trybe.atlassian.net/browse/LEARN-869?atlOrigin=eyJpIjoiNjk5MjBkZDIzNTM2NDY5NmExMGJjYmRjN2NlZDAzYjAiLCJwIjoiaiJ9) e como o _workflow_ é disparado via **Github App Selfhosted**, a envvar `GITHUB_ACTOR` não poderá ser usada para pegar o **username** da pessoa estudante. Além disso, o **número** da Pull Request não vem no contexto do evento da _action_. Foi modificado para estes dados serem enviados pelo Github App via _input_. Assim sendo, será necessário modificar os avaliadores para o novo formato.