### PR TITLE
fix: remove o default de exclude para flake8

### DIFF
--- a/report.cfg
+++ b/report.cfg
@@ -1,6 +1,4 @@
 [flake8]
-exclude = .git,__pycache__,.venv
-
 verbose = 0
 quiet = 0
 


### PR DESCRIPTION
Agora fica na responsabilidade do repositório do projeto, e não da action, definir quais diretórios serão excluídos do linter