### PR TITLE
fix: usa venv para instalar dependências

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,21 +7,16 @@ inputs:
   pr_number:
     description: 'Pull Request number that trigger build.'
     required: true
+
 runs:
   using: 'composite'
   steps:
     - id: run_flake8
       shell: bash
       run: ${{ github.action_path }}/lint.sh
-
-    - id: setup_evaluator
-      shell: bash
-      run: python3 -m pip install -r ${{ github.action_path }}/requirements.txt
-
-    - id: comment_on_pr
-      shell: bash
-      run: python3 ${{ github.action_path }}/src/main.py /tmp/flake8.log
       env:
         INPUT_TOKEN: ${{ inputs.token }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        EVALUATOR_REQUIREMENTS: ${{ github.action_path }}/requirements.txt
+        EVALUATOR_SRC: ${{ github.action_path }}/src

--- a/lint.sh
+++ b/lint.sh
@@ -4,9 +4,9 @@
 python3 -m venv "~/.github/venv/$INPUT_PR_NUMBER" --system-site-packages
 source "~/.github/venv/$INPUT_PR_NUMBER/bin/activate"
 if test -f "dev-requirements.txt" ; then
-  python3 -m pip install -r dev-requirements.txt
+  python3 -m pip install -r dev-requirements.txt --no-cache-dir
 else
-  python3 -m pip install -r requirements.txt
+  python3 -m pip install -r requirements.txt --no-cache-dir
 fi
 python3 -m flake8 --append-config=setup.cfg --append-config=/home/report.cfg > /tmp/flake8.log
 

--- a/lint.sh
+++ b/lint.sh
@@ -1,9 +1,16 @@
-#!/bin/sh -l
+#!/bin/bash
 
 # Run flake8 over the student source and generate a log report
+python3 -m venv "~/.github/venv/$INPUT_PR_NUMBER" --system-site-packages
+source "~/.github/venv/$INPUT_PR_NUMBER/bin/activate"
 if test -f "dev-requirements.txt" ; then
   python3 -m pip install -r dev-requirements.txt
 else
   python3 -m pip install -r requirements.txt
 fi
 python3 -m flake8 --append-config=setup.cfg --append-config=/home/report.cfg > /tmp/flake8.log
+
+python3 -m venv "~/.github/venv/$INPUT_PR_NUMBER-linter" --system-site-packages
+source "~/.github/venv/$INPUT_PR_NUMBER-linter/bin/activate"
+python3 -m pip install -r "$EVALUATOR_REQUIREMENTS"
+python3 "$EVALUATOR_SRC/main.py" /tmp/flake8.log


### PR DESCRIPTION
Ao rodar o python diretamente no runner (ao invés do docker) gerou erros ao instalar as dependências de alguns projetos ([exemplo](https://betrybe.slack.com/archives/C02CLK67CBB/p1641842752125700) de erro reportado), esta PR instala as dependências usando [venv](https://docs.python.org/3/library/venv.html) isolando o ambiente do projeto evitando os erros.