### PR TITLE
fix: instala dependências na pasta correta .venv

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Run flake8 over the student source and generate a log report
-python3 -m venv "~/.github/venv/$INPUT_PR_NUMBER" --system-site-packages
-source "~/.github/venv/$INPUT_PR_NUMBER/bin/activate"
+python3 -m venv ".venv/$INPUT_PR_NUMBER" --system-site-packages
+source ".venv/$INPUT_PR_NUMBER/bin/activate"
 if test -f "dev-requirements.txt" ; then
   python3 -m pip install -r dev-requirements.txt --no-cache-dir
 else
@@ -10,7 +10,7 @@ else
 fi
 python3 -m flake8 --append-config=setup.cfg --append-config=/home/report.cfg > /tmp/flake8.log
 
-python3 -m venv "~/.github/venv/$INPUT_PR_NUMBER-linter" --system-site-packages
-source "~/.github/venv/$INPUT_PR_NUMBER-linter/bin/activate"
+python3 -m venv ".venv/$INPUT_PR_NUMBER-linter" --system-site-packages
+source ".venv/$INPUT_PR_NUMBER-linter/bin/activate"
 python3 -m pip install -r "$EVALUATOR_REQUIREMENTS"
 python3 "$EVALUATOR_SRC/main.py" /tmp/flake8.log

--- a/src/main.py
+++ b/src/main.py
@@ -71,6 +71,7 @@ def comment_on_pr(comment):
     repo = github.get_repo(os.getenv('GITHUB_REPOSITORY'))
     pull_request = repo.get_pull(int(os.getenv('INPUT_PR_NUMBER', '1')))
 
+    print(comment)
     pull_request.create_issue_comment(comment)
 
 


### PR DESCRIPTION
Conforme [erro](https://betrybe.slack.com/archives/C02CLK67CBB/p1642435298297900) reportado o Flake8 tava validando tudo o que estava dentro das dependências do `.venv` também, por isso o comentário estourava o limite de caracteres, ajustei para criar a pasta no caminho correto, já contém no [exclude](https://github.com/betrybe/flake8-linter-action/blob/master/setup.cfg#L2) do Flake8 a pasta `.venv`, então ela vai ser ignorada 